### PR TITLE
feat: add onChange handler to proxyWithHistory

### DIFF
--- a/packages/history-utility/docs/modules.md
+++ b/packages/history-utility/docs/modules.md
@@ -7,6 +7,7 @@
 ### Type Aliases
 
 - [History](modules.md#history)
+- [HistoryChangeMetadata](modules.md#historychangemetadata)
 - [HistoryNode](modules.md#historynode)
 - [HistoryOptions](modules.md#historyoptions)
 
@@ -36,7 +37,24 @@
 
 #### Defined in
 
-[packages/history-utility/src/history-utility.ts:26](https://github.com/valtiojs/valtio-history/blob/43e2fcd/packages/history-utility/src/history-utility.ts#L26)
+[packages/history-utility/src/history-utility.ts:26](https://github.com/valtiojs/valtio-history/blob/1c4e781/packages/history-utility/src/history-utility.ts#L26)
+
+---
+
+### HistoryChangeMetadata
+
+Ƭ **HistoryChangeMetadata**: `Object`
+
+#### Type declaration
+
+| Name           | Type      | Description                                             |
+| :------------- | :-------- | :------------------------------------------------------ |
+| `historySaved` | `boolean` | is true when the value has been changed by the consumer |
+| `ops`          | `any`[]   | the operations that caused the history change           |
+
+#### Defined in
+
+[packages/history-utility/src/history-utility.ts:43](https://github.com/valtiojs/valtio-history/blob/1c4e781/packages/history-utility/src/history-utility.ts#L43)
 
 ---
 
@@ -60,23 +78,30 @@
 
 #### Defined in
 
-[packages/history-utility/src/history-utility.ts:10](https://github.com/valtiojs/valtio-history/blob/43e2fcd/packages/history-utility/src/history-utility.ts#L10)
+[packages/history-utility/src/history-utility.ts:10](https://github.com/valtiojs/valtio-history/blob/1c4e781/packages/history-utility/src/history-utility.ts#L10)
 
 ---
 
 ### HistoryOptions
 
-Ƭ **HistoryOptions**: `Object`
+Ƭ **HistoryOptions**\<`T`\>: `Object`
+
+#### Type parameters
+
+| Name |
+| :--- |
+| `T`  |
 
 #### Type declaration
 
-| Name             | Type      | Description                                                       |
-| :--------------- | :-------- | :---------------------------------------------------------------- |
-| `skipSubscribe?` | `boolean` | determines if the internal subscribe behaviour should be skipped. |
+| Name             | Type                                                                                          | Description                                                        |
+| :--------------- | :-------------------------------------------------------------------------------------------- | :----------------------------------------------------------------- |
+| `skipSubscribe?` | `boolean`                                                                                     | determines if the internal subscribe behaviour should be skipped.  |
+| `onChange?`      | (`value`: `T`, `data`: [`HistoryChangeMetadata`](modules.md#historychangemetadata)) => `void` | callback that triggers any time a change happens wihin the utility |
 
 #### Defined in
 
-[packages/history-utility/src/history-utility.ts:43](https://github.com/valtiojs/valtio-history/blob/43e2fcd/packages/history-utility/src/history-utility.ts#L43)
+[packages/history-utility/src/history-utility.ts:54](https://github.com/valtiojs/valtio-history/blob/1c4e781/packages/history-utility/src/history-utility.ts#L54)
 
 ## Functions
 
@@ -114,10 +139,10 @@ Notes: <br>
 
 #### Parameters
 
-| Name           | Type                                                       | Description                                    |
-| :------------- | :--------------------------------------------------------- | :--------------------------------------------- |
-| `initialValue` | `V`                                                        | any value to be tracked                        |
-| `options?`     | `boolean` \| [`HistoryOptions`](modules.md#historyoptions) | use to configure the proxyWithHistory utility. |
+| Name           | Type                                                              | Description                                    |
+| :------------- | :---------------------------------------------------------------- | :--------------------------------------------- |
+| `initialValue` | `V`                                                               | any value to be tracked                        |
+| `options?`     | `boolean` \| [`HistoryOptions`](modules.md#historyoptions)\<`V`\> | use to configure the proxyWithHistory utility. |
 
 #### Returns
 
@@ -154,4 +179,4 @@ const state = proxyWithHistory({
 
 #### Defined in
 
-[packages/history-utility/src/history-utility.ts:129](https://github.com/valtiojs/valtio-history/blob/43e2fcd/packages/history-utility/src/history-utility.ts#L129)
+[packages/history-utility/src/history-utility.ts:147](https://github.com/valtiojs/valtio-history/blob/1c4e781/packages/history-utility/src/history-utility.ts#L147)

--- a/packages/history-utility/docs/modules.md
+++ b/packages/history-utility/docs/modules.md
@@ -37,7 +37,7 @@
 
 #### Defined in
 
-[packages/history-utility/src/history-utility.ts:26](https://github.com/valtiojs/valtio-history/blob/1c4e781/packages/history-utility/src/history-utility.ts#L26)
+[packages/history-utility/src/history-utility.ts:26](https://github.com/valtiojs/valtio-history/blob/6de9669/packages/history-utility/src/history-utility.ts#L26)
 
 ---
 
@@ -50,11 +50,10 @@
 | Name           | Type      | Description                                             |
 | :------------- | :-------- | :------------------------------------------------------ |
 | `historySaved` | `boolean` | is true when the value has been changed by the consumer |
-| `ops`          | `any`[]   | the operations that caused the history change           |
 
 #### Defined in
 
-[packages/history-utility/src/history-utility.ts:43](https://github.com/valtiojs/valtio-history/blob/1c4e781/packages/history-utility/src/history-utility.ts#L43)
+[packages/history-utility/src/history-utility.ts:43](https://github.com/valtiojs/valtio-history/blob/6de9669/packages/history-utility/src/history-utility.ts#L43)
 
 ---
 
@@ -78,7 +77,7 @@
 
 #### Defined in
 
-[packages/history-utility/src/history-utility.ts:10](https://github.com/valtiojs/valtio-history/blob/1c4e781/packages/history-utility/src/history-utility.ts#L10)
+[packages/history-utility/src/history-utility.ts:10](https://github.com/valtiojs/valtio-history/blob/6de9669/packages/history-utility/src/history-utility.ts#L10)
 
 ---
 
@@ -101,7 +100,7 @@
 
 #### Defined in
 
-[packages/history-utility/src/history-utility.ts:54](https://github.com/valtiojs/valtio-history/blob/1c4e781/packages/history-utility/src/history-utility.ts#L54)
+[packages/history-utility/src/history-utility.ts:50](https://github.com/valtiojs/valtio-history/blob/6de9669/packages/history-utility/src/history-utility.ts#L50)
 
 ## Functions
 
@@ -179,4 +178,4 @@ const state = proxyWithHistory({
 
 #### Defined in
 
-[packages/history-utility/src/history-utility.ts:147](https://github.com/valtiojs/valtio-history/blob/1c4e781/packages/history-utility/src/history-utility.ts#L147)
+[packages/history-utility/src/history-utility.ts:143](https://github.com/valtiojs/valtio-history/blob/6de9669/packages/history-utility/src/history-utility.ts#L143)

--- a/packages/history-utility/src/__tests__/history-utility.vanilla.spec.ts
+++ b/packages/history-utility/src/__tests__/history-utility.vanilla.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { HistoryNode, proxyWithHistory } from '../history-utility';
 
@@ -23,6 +23,39 @@ describe('proxyWithHistory: vanilla', () => {
       state.redo();
       await Promise.resolve();
       expect(state.value.count).toEqual(1);
+    });
+
+    it('should call onChange when provided', async () => {
+      const onChange = vi.fn();
+      const state = proxyWithHistory({ count: 0 }, { onChange });
+      await Promise.resolve();
+      expect(state.value.count).toEqual(0);
+
+      state.value.count += 1;
+      await Promise.resolve();
+      expect(state.value.count).toEqual(1);
+      expect(onChange).toBeCalledWith(
+        { count: 1 },
+        expect.objectContaining({ historySaved: true })
+      );
+
+      state.undo();
+      await Promise.resolve();
+      expect(state.value.count).toEqual(0);
+      expect(onChange).toBeCalledWith(
+        { count: 0 },
+        expect.objectContaining({ historySaved: false })
+      );
+
+      state.redo();
+      await Promise.resolve();
+      expect(state.value.count).toEqual(1);
+      expect(onChange).toBeCalledWith(
+        { count: 1 },
+        expect.objectContaining({ historySaved: false })
+      );
+
+      expect(onChange).toHaveBeenCalledTimes(3);
     });
 
     it('should provide basic sequential undo functionality', async () => {

--- a/packages/history-utility/src/history-utility.ts
+++ b/packages/history-utility/src/history-utility.ts
@@ -42,10 +42,6 @@ type SubscribeOps = Parameters<Parameters<typeof subscribe>[1]>[0];
 
 export type HistoryChangeMetadata = {
   /**
-   * the operations that caused the history change
-   */
-  ops: SubscribeOps;
-  /**
    * is true when the value has been changed by the consumer
    */
   historySaved: boolean;
@@ -270,7 +266,6 @@ export function proxyWithHistory<V>(
         if (shouldSaveHistory) proxyObject.saveHistory();
 
         utilOptions.onChange?.(proxyObject.value, {
-          ops,
           historySaved: shouldSaveHistory,
         });
       }),
@@ -351,9 +346,7 @@ export function proxyWithHistory<V>(
 
   proxyObject.saveHistory();
 
-  if (!utilOptions.skipSubscribe) {
-    proxyObject.subscribe();
-  }
+  if (!utilOptions.skipSubscribe) proxyObject.subscribe();
 
   return proxyObject;
 }


### PR DESCRIPTION
Add onChange handler for `proxyWithHistory` to provide a convenient event without setting up a custom subscribe handler.

helpful in a react render to avoid a hacky `useEffect`


Interface
```tsx
const Provider = ({ data,  onChange }) ={
   const state = useRef(proxyWithHistory(data, { onChange })).current;

   return (
    <Context.Provider value={state}>
      {children}
    </Context.Provider>
  );
}
```