### PR TITLE
feat: add getters for history util values

### DIFF
--- a/packages/history-utility/src/__tests__/history-utility.vanilla.spec.ts
+++ b/packages/history-utility/src/__tests__/history-utility.vanilla.spec.ts
@@ -31,30 +31,40 @@ describe('proxyWithHistory: vanilla', () => {
       expect(state.value.count).toEqual(0);
       expect(state.canRedo()).toEqual(false);
       expect(state.canUndo()).toEqual(false);
+      expect(state.isRedoEnabled).toEqual(false);
+      expect(state.isUndoEnabled).toEqual(false);
 
       state.value.count += 1;
       await Promise.resolve();
       expect(state.value.count).toEqual(1);
       expect(state.canRedo()).toEqual(false);
       expect(state.canUndo()).toEqual(true);
+      expect(state.isRedoEnabled).toEqual(false);
+      expect(state.isUndoEnabled).toEqual(true);
 
       state.value.count += 1;
       await Promise.resolve();
       expect(state.value.count).toEqual(2);
       expect(state.canRedo()).toEqual(false);
       expect(state.canUndo()).toEqual(true);
+      expect(state.isRedoEnabled).toEqual(false);
+      expect(state.isUndoEnabled).toEqual(true);
 
       state.undo();
       await Promise.resolve();
       expect(state.value.count).toEqual(1);
       expect(state.canRedo()).toEqual(true);
       expect(state.canUndo()).toEqual(true);
+      expect(state.isRedoEnabled).toEqual(true);
+      expect(state.isUndoEnabled).toEqual(true);
 
       state.undo();
       await Promise.resolve();
       expect(state.value.count).toEqual(0);
       expect(state.canRedo()).toEqual(true);
       expect(state.canUndo()).toEqual(false);
+      expect(state.isRedoEnabled).toEqual(true);
+      expect(state.isUndoEnabled).toEqual(false);
     });
 
     it('should provide basic sequential redo functionality', async () => {
@@ -76,24 +86,32 @@ describe('proxyWithHistory: vanilla', () => {
       expect(state.value.count).toEqual(0);
       expect(state.canRedo()).toEqual(true);
       expect(state.canUndo()).toEqual(false);
+      expect(state.isRedoEnabled).toEqual(true);
+      expect(state.isUndoEnabled).toEqual(false);
 
       state.redo();
       await Promise.resolve();
       expect(state.value.count).toEqual(1);
       expect(state.canRedo()).toEqual(true);
       expect(state.canUndo()).toEqual(true);
+      expect(state.isRedoEnabled).toEqual(true);
+      expect(state.isUndoEnabled).toEqual(true);
 
       state.redo();
       await Promise.resolve();
       expect(state.value.count).toEqual(2);
       expect(state.canRedo()).toEqual(true);
       expect(state.canUndo()).toEqual(true);
+      expect(state.isRedoEnabled).toEqual(true);
+      expect(state.isUndoEnabled).toEqual(true);
 
       state.redo();
       await Promise.resolve();
       expect(state.value.count).toEqual(3);
       expect(state.canRedo()).toEqual(false);
       expect(state.canUndo()).toEqual(true);
+      expect(state.isRedoEnabled).toEqual(false);
+      expect(state.isUndoEnabled).toEqual(true);
     });
   });
 

--- a/packages/history-utility/src/index.ts
+++ b/packages/history-utility/src/index.ts
@@ -150,10 +150,20 @@ export function proxyWithHistory<V>(
     /**
      * get the date when a node was entered into history.
      *
+     * @deprecated @see {@link https://github.com/valtiojs/valtio-history/issues/10}
      * @returns date
      */
     getCurrentChangeDate: () => {
       const node = proxyObject.history.nodes[proxyObject.history.index];
+      return node?.createdAt;
+    },
+    /**
+     * get the date when a node was entered into history.
+     *
+     * @returns date
+     */
+    get currentChangeDate() {
+      const node = this.history.nodes[this.history.index];
       return node?.createdAt;
     },
     /**
@@ -187,7 +197,23 @@ export function proxyWithHistory<V>(
       proxyObject.history.index = index;
     },
     /**
+     * a getter to return true if undo is available
+     * @returns boolean
+     */
+    get isUndoEnabled() {
+      return this.history.index > 0;
+    },
+    /**
+     * a getter to return true if redo is available
+     * @returns boolean
+     */
+    get isRedoEnabled() {
+      return this.history.index < this.history.nodes.length - 1;
+    },
+    /**
      * a function to return true if undo is available
+     *
+     * @deprecated @see {@link https://github.com/valtiojs/valtio-history/issues/10}
      * @returns boolean
      */
     canUndo: () => proxyObject.history.index > 0,
@@ -204,6 +230,8 @@ export function proxyWithHistory<V>(
     },
     /**
      * a function to return true if redo is available
+     *
+     * @deprecated @see {@link https://github.com/valtiojs/valtio-history/issues/10}
      * @returns boolean
      */
     canRedo: () =>


### PR DESCRIPTION
canUndo, canRedo and getCurrentChangeDate do not cause a component to re-render when used by themselves.

To resolve this equivalent getters are exposed to directly access the intended values

closes #10 