### PR TITLE
fix: declare explicit return type for getNode

### DIFF
--- a/packages/history-utility/src/index.ts
+++ b/packages/history-utility/src/index.ts
@@ -182,7 +182,7 @@ export function proxyWithHistory<V>(
      * @param index
      * @returns historyNode
      */
-    getNode: (index: number) => {
+    getNode: (index: number): HistoryNode<V> | undefined => {
       const node = proxyObject.history.nodes[index];
       return node
         ? { ...node, snapshot: proxyObject.clone(node.snapshot) }


### PR DESCRIPTION
Addressing #12 by explicitly defining the return type of `getNode`.

Turns 
![image](https://github.com/valtiojs/valtio-history/assets/18403470/b9d51e11-2c05-4ddb-936f-658a3d591e21)

Into

![image](https://github.com/valtiojs/valtio-history/assets/18403470/3484d354-cd82-464a-b043-05d72bb9e7da)
