### PR TITLE
fix: use unstable_enableOp

### DIFF
--- a/packages/history-utility/src/index.ts
+++ b/packages/history-utility/src/index.ts
@@ -1,6 +1,18 @@
-import { proxy, ref, snapshot, subscribe } from 'valtio/vanilla';
 import type { Snapshot } from 'valtio/vanilla';
+import * as valtioVanilla from 'valtio/vanilla';
 import { deepClone } from 'valtio/vanilla/utils';
+
+const { proxy, ref, snapshot, subscribe } = valtioVanilla;
+
+// Enable ops in subscribe callback - required for valtio-history to receive change operations
+// This is a global opt-in as of valtio v2.3.0 (see https://github.com/pmndrs/valtio/pull/1189)
+// We check for existence to maintain backwards compatibility with older valtio versions
+if (
+  'unstable_enableOp' in valtioVanilla &&
+  typeof valtioVanilla.unstable_enableOp === 'function'
+) {
+  valtioVanilla.unstable_enableOp(true);
+}
 
 export type HistoryNode<T> = {
   /**

--- a/packages/history-utility/src/index.ts
+++ b/packages/history-utility/src/index.ts
@@ -2,17 +2,15 @@ import type { Snapshot } from 'valtio/vanilla';
 import * as valtioVanilla from 'valtio/vanilla';
 import { deepClone } from 'valtio/vanilla/utils';
 
-const { proxy, ref, snapshot, subscribe } = valtioVanilla;
+const { proxy, ref, snapshot, subscribe, unstable_enableOp } =
+  valtioVanilla as typeof valtioVanilla & {
+    unstable_enableOp?: (enabled: boolean) => void;
+  };
 
 // Enable ops in subscribe callback - required for valtio-history to receive change operations
 // This is a global opt-in as of valtio v2.3.0 (see https://github.com/pmndrs/valtio/pull/1189)
 // We check for existence to maintain backwards compatibility with older valtio versions
-if (
-  'unstable_enableOp' in valtioVanilla &&
-  typeof valtioVanilla.unstable_enableOp === 'function'
-) {
-  valtioVanilla.unstable_enableOp(true);
-}
+unstable_enableOp?.(true);
 
 export type HistoryNode<T> = {
   /**


### PR DESCRIPTION
If the valtio package exports a `unstable_enableOp` function, is its called atop of the main file to enable operation callbacks in the subscribe function. This is needed for valtio versions gte to [2.3.0](https://github.com/pmndrs/valtio/releases/tag/v2.3.0) 

Code is copied almost verbatim from https://github.com/valtiojs/valtio-y/commit/ef84c315d0ca3d93e6421eb49ea65fc599fb19f3

ref https://github.com/pmndrs/valtio/pull/1189
fix #25